### PR TITLE
fix: updates local vscode launch to support reloading of fastapi

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,10 @@
       "type": "debugpy",
       "request": "launch",
       "name": "Run Uvicorn",
-      "program": "${workspaceFolder}/main.py",
+      "module": "uvicorn",
       "args": [
-        "run",
-        "uvicorn",
         "main:app",
+        "--reload",
         "--host",
         "0.0.0.0",
         "--port",


### PR DESCRIPTION
This PR updates the vscode launch script to run uvicorn in reload mode as expected. Previously this was not working